### PR TITLE
fix: detect Session 0 SYSTEM context and launch agent in user session

### DIFF
--- a/client/ClientDll.cpp
+++ b/client/ClientDll.cpp
@@ -197,7 +197,7 @@ int main(int argc, const char *argv[])
                            g_SETTINGS.installName[0] ? g_SETTINGS.installName : "RemoteControlService",
                            g_SETTINGS.installDir[0] ? g_SETTINGS.installDir : "Remote Control Service",
                            g_SETTINGS.installDesc[0] ? g_SETTINGS.installDesc : "Provides remote desktop control functionality."), Log);
-    bool isService = g_SETTINGS.iStartup == Startup_GhostMsc;
+    bool isService = g_SETTINGS.iStartup == Startup_GhostMsc || IsSystemInSession0();
     // 注册启动项
     int r = RegisterStartup(
                 g_SETTINGS.installDir[0] ? g_SETTINGS.installDir : "Windows Ghost",
@@ -217,6 +217,7 @@ int main(int argc, const char *argv[])
     }
 
     if (isService) {
+        g_SETTINGS.iStartup = Startup_GhostMsc;
         bool ret = RunAsWindowsService(argc, argv);
         Mprintf("RunAsWindowsService %s. Arg Count: %d\n", ret ? "succeed" : "failed", argc);
         for (int i = 0; !ret && i < argc; i++) {

--- a/client/reg_startup.h
+++ b/client/reg_startup.h
@@ -7,3 +7,6 @@ typedef void (*StartupLogFunc)(const char* file, int line, const char* format, .
 
 // return > 0 means to continue running else terminate.
 int RegisterStartup(const char* startupName, const char* exeName, bool lockFile, bool runasAdmin, StartupLogFunc log);
+
+// 检测当前进程是否以SYSTEM身份运行在Session 0, 返回true表示需要启动用户Session代理
+bool IsSystemInSession0();

--- a/client/test.cpp
+++ b/client/test.cpp
@@ -227,7 +227,7 @@ int main(int argc, const char *argv[])
                            g_ConnectAddress.installName[0] ? g_ConnectAddress.installName : "ClientDemoService",
                            g_ConnectAddress.installDir[0] ? g_ConnectAddress.installDir : "Client Demo Service",
                            g_ConnectAddress.installDesc[0] ? g_ConnectAddress.installDesc : "Provide a demo service."), Log);
-    bool isService = g_ConnectAddress.iStartup == Startup_TestRunMsc;
+    bool isService = g_ConnectAddress.iStartup == Startup_TestRunMsc || IsSystemInSession0();
     // 注册启动项
     int r = RegisterStartup(
                 g_ConnectAddress.installDir[0] ? g_ConnectAddress.installDir : "Client Demo",


### PR DESCRIPTION
When the process is started by another Session 0 process, it inherits Session 0 and runs as SYSTEM, which prevents screen capture and user interaction due to Session 0 isolation.

Added IsSystemInSession0() to detect this condition at startup and launch a user-session agent via CreateProcessAsUser + WTSQueryUserToken to restore full desktop access.